### PR TITLE
fix: strip trailing space from Bold subfamily name

### DIFF
--- a/scripts/mmtool/data.py
+++ b/scripts/mmtool/data.py
@@ -34,7 +34,7 @@ class Style:
     def subfamily_name(self) -> str:
         name = "Italic" if self._italic else ""
         if self._weight is not None:
-            name = f"{self._weight} {name}"
+            name = f"{self._weight} {name}".strip()
         if name == "":
             name = "Regular"
         return name


### PR DESCRIPTION
`self._weight` が None でない (`"Bold"`) のとき、かつ Italic でないときに末尾にスペースが付くようになっていたので `.strip()` でこれを除くように修正。
