### PR TITLE
fix: drop PfEd-lookups flag to avoid font-patcher crash

### DIFF
--- a/scripts/momiage-mono.py
+++ b/scripts/momiage-mono.py
@@ -139,10 +139,16 @@ def generate_momiage_mono(target: Target, filename: Path):
 
     # Finalize
     font_action.set_info(font, target)
+    # NOTE: Do not emit the "PfEd-lookups" flag. It stores FontForge's private
+    # lookup metadata (inherited from JetBrains Mono's imported GSUB lookups)
+    # into the PfEd table, and that data makes fontforge's glyph.getPosSub()
+    # raise on read. That in turn crashes the Nerd Fonts font-patcher in
+    # get_essential_references(). PfEd is editor-only metadata and is not needed
+    # in the distributed font.
     font.generate(
         str(filename),
         "",
-        ("short-post", "PfEd-lookups", "opentype")
+        ("short-post", "opentype")
     )
 
 


### PR DESCRIPTION
`font.generate()` の出力フラグから `PfEd-lookups` を除きます。

`PfEd-lookups` フラグは JetBrains Mono 由来の GSUB lookup のメタデータを PfEd テーブルに書き込みます。
本フラグを外すことで、font-patcher がこれを読む際にクラッシュして Nerd Font 版がビルドできない問題を解決します (エラー内容は以下 fold に)。

<details>
<summary>font-patcher の出力 (エラー)</summary>

```
~/repository/MomiageMono/dist ~/repository/MomiageMono
Program root: /usr
Nerd Fonts Patcher v3.4.0 (4.20.3) (ff 20230101)
Warning: Mac string is a subset of the Windows string in the 'name' table
 for the Copyright string in the English (US) language.
WARNING: Monospaced check: Panose assumed to be wrong
WARNING: Monospaced check: Advance widths (base/extended): 1228 - 1228 / 1228 - 1228 and Panose says "not monospaced"
INFO: Setting Panose 'Proportion' to 'Monospaced' (was 'Modern')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb7 in position 0: invalid start byte

The above exception was the direct cause of the following exception:

SystemError: <class 'UnicodeDecodeError'> returned a result with an exception set

The above exception was the direct cause of the following exception:

SystemError: <class 'UnicodeDecodeError'> returned a result with an exception set

The above exception was the direct cause of the following exception:

SystemError: <class 'UnicodeDecodeError'> returned a result with an exception set

The above exception was the direct cause of the following exception:

SystemError: <class 'UnicodeDecodeError'> returned a result with an exception set

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/kobi/repository/MomiageMono/dist/../fonts/nerd-fonts-patcher/font-patcher", line 2296, in <module>
    main()
  File "/home/kobi/repository/MomiageMono/dist/../fonts/nerd-fonts-patcher/font-patcher", line 2283, in main
    patcher.patch(sourceFonts[-1])
  File "/home/kobi/repository/MomiageMono/dist/../fonts/nerd-fonts-patcher/font-patcher", line 354, in patch
    self.get_essential_references()
  File "/home/kobi/repository/MomiageMono/dist/../fonts/nerd-fonts-patcher/font-patcher", line 1197, in get_essential_references
    for possub in self.sourceFont[glyph].getPosSub('*'):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SystemError: <method 'getPosSub' of 'fontforge.glyph' objects> returned a result with an exception set
```

</details>

副次的に `Internal Error: Attempt to output 65551 into a 16-bit field. It will be truncated and the file may not be useful.` の警告も解消します。